### PR TITLE
Update for RORPO_multiscale_Usage: dependency checking and installation

### DIFF
--- a/RORPO_multiscale_Usage/CMakeLists.txt
+++ b/RORPO_multiscale_Usage/CMakeLists.txt
@@ -31,7 +31,9 @@ file(GLOB_RECURSE HEADER_FILES *.hpp *.h)
 file(GLOB_RECURSE SOURCE_FILES *.cpp)
 
 add_executable( ${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries( ${PROJECT_NAME} ${NIFTI_LIB} ${RORPO_LIB} ${DOCOPT_LIB})
+target_link_libraries( ${PROJECT_NAME} Nifti RORPO docopt )
+
+install( TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin/ )
 
 #if(NIFTI_LIB AND RORPO_LIB)
 #    target_link_libraries( ${PROJECT_NAME} ${NIFTI_LIB} ${VTK_LIBRARIES} ${RORPO_LIB} )


### PR DESCRIPTION
- Updated libraries to be linked with RORPO_multiscale_Usage. We propose
  to directly use the target names instead of the paths to libraries to
  help with dependency checking.
  This allows to solve issues when building with high number of jobs (make -j X),
  as sometimes libRORPO might not be built before we try to build RORPO_multiscale_Usage.
- Added installation instructions for RORPO_multiscale_Usage.