### PR TITLE
Added canonical installation for libNifti

### DIFF
--- a/Image/Nifti/CMakeLists.txt
+++ b/Image/Nifti/CMakeLists.txt
@@ -15,4 +15,5 @@ add_library(Nifti ${LIB_TYPE} ${NIFTI_SOURCES})
 
 install( FILES ${NIFTI_HEADERS} DESTINATION include/Nifti)
 install( TARGETS Nifti DESTINATION ${CMAKE_BINARY_DIR}/lib)
+install( TARGETS Nifti LIBRARY DESTINATION lib)
 


### PR DESCRIPTION
I noticed an issue with the Nifti library not installed in the specified installation path.
With this PR, I just added a new installation target for this library (it doesn't change the current behavior), but still allows to install this library in the path specified by CMAKE_INSTALL_PREFIX.