### PR TITLE
 fix cmake error

### DIFF
--- a/Image/Nifti/CMakeLists.txt
+++ b/Image/Nifti/CMakeLists.txt
@@ -15,5 +15,7 @@ add_library(Nifti ${LIB_TYPE} ${NIFTI_SOURCES})
 
 install( FILES ${NIFTI_HEADERS} DESTINATION include/Nifti)
 install( TARGETS Nifti DESTINATION ${CMAKE_BINARY_DIR}/lib)
-install( TARGETS Nifti LIBRARY DESTINATION lib)
+install( TARGETS 
+        Nifti LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
 


### PR DESCRIPTION
when use cmake3.9 and vs2015, there is a "install TARGETS given no ARCHIVE DESTINATION ..." error.