### PR TITLE
remove warnings from fread and fscanf

### DIFF
--- a/libRORPO/src/mcimage.c
+++ b/libRORPO/src/mcimage.c
@@ -2302,7 +2302,7 @@ struct xvimage * readimage( const char *filename )
                   uint8_t tmp1;
                   for (i = 0; i < N; i++)
                   {
-                      (void)fread(&tmp, sizeof(uint16_t), 1, fd);
+                      bool = fread(&tmp, sizeof(uint16_t), 1, fd);
                       // conversion big-endian -> little-endian
                       tmp1 = tmp & 0x00ff;
                       tmp = tmp >> 8;

--- a/libRORPO/src/mcimage.c
+++ b/libRORPO/src/mcimage.c
@@ -2062,6 +2062,7 @@ struct xvimage * readimage( const char *filename )
   double xdim=1.0, ydim=1.0, zdim=1.0;
   char *read;
   char tag;
+  int bool;
 
   fd = pink_fopen_read(filename);
 
@@ -2226,11 +2227,11 @@ struct xvimage * readimage( const char *filename )
 	      b3 = b2 + N;
 	      for (i = 0; i < N; i++)
               {
-		fscanf(fd, "%d", &c);
+		bool = fscanf(fd, "%d", &c);
 		b1[i] = (uint8_t)c;
-		fscanf(fd, "%d", &c);
+		bool = fscanf(fd, "%d", &c);
 		b2[i] = (uint8_t)c;
-		fscanf(fd, "%d", &c);
+		bool = fscanf(fd, "%d", &c);
 		b3[i] = (uint8_t)c;
               } // for i
 	    } // if color
@@ -2239,7 +2240,7 @@ struct xvimage * readimage( const char *filename )
 	      N = rs * cs * ds * nb;
 	      for (i = 0; i < N; i++)
               {
-                  fscanf(fd, "%d", &c);
+                  bool = fscanf(fd, "%d", &c);
                   UCHARDATA(image)[i] = (uint8_t)c;
               } // for i
 	    }
@@ -2292,7 +2293,7 @@ struct xvimage * readimage( const char *filename )
                   uint16_t tmp;
                   for (i = 0; i < N; i++)
                   {
-                      fscanf(fd, "%hd", &tmp); (SSHORTDATA(image)[i]) = tmp;
+                      bool = fscanf(fd, "%hd", &tmp); (SSHORTDATA(image)[i]) = tmp;
                   } /* for i */
               }
               else // Standard PGM format imposes big-endian for 2-byte images, but
@@ -2318,7 +2319,7 @@ struct xvimage * readimage( const char *filename )
                       long int tmp;
                       for (i = 0; i < N; i++)
                       {
-                          fscanf(fd, "%ld", &tmp); (SLONGDATA(image)[i]) = (int32_t)tmp;
+                          bool = fscanf(fd, "%ld", &tmp); (SLONGDATA(image)[i]) = (int32_t)tmp;
                       } /* for i */
                   }
                   else
@@ -2342,7 +2343,7 @@ struct xvimage * readimage( const char *filename )
                       {
                           for (i = 0; i < N; i++)
                           {
-                              fscanf(fd, "%f", &(FLOATDATA(image)[i]));
+                              bool = fscanf(fd, "%f", &(FLOATDATA(image)[i]));
                           } /* for i */
                       }
                       else
@@ -2366,7 +2367,7 @@ struct xvimage * readimage( const char *filename )
                           {
                               for (i = 0; i < N; i++)
                               {
-                                  fscanf(fd, "%lf", &(DOUBLEDATA(image)[i]));
+                                  bool = fscanf(fd, "%lf", &(DOUBLEDATA(image)[i]));
                               } /* for i */
                           }
                           else
@@ -2390,7 +2391,7 @@ struct xvimage * readimage( const char *filename )
                               {
                                   for (i = 0; i < N+N; i++)
                                   {
-                                      fscanf(fd, "%f", &(FLOATDATA(image)[i]));
+                                      bool = fscanf(fd, "%f", &(FLOATDATA(image)[i]));
                                   } /* for i */
                               }
                               else
@@ -2539,6 +2540,7 @@ de la forme :
   int32_t c, ndgmax;
   int32_t dimorigin = 0;
   char *read;
+  int bool;
 
   fd = pink_fopen_read(filename);
 
@@ -2644,13 +2646,13 @@ de la forme :
       if (ndgmax == 255)
         for (i = 0; i < N; i++)
         {
-          fscanf(fd, "%d", &c);
+          bool = fscanf(fd, "%d", &c);
           UCHARDATA(image)[i] = (uint8_t)c;
         } /* for i */
       else if (ndgmax == 65535)
         for (i = 0; i < N; i++)
         {
-          fscanf(fd, "%d", &c);
+          bool = fscanf(fd, "%d", &c);
           UCHARDATA(image)[i] = (uint8_t)(c/256);
         } /* for i */
       else
@@ -2710,6 +2712,7 @@ int32_t readrgbimage(
   int32_t c;
   char *read;
   int32_t nndg, ndgmax;
+  int bool;
 
   fd = pink_fopen_read(filename);
 
@@ -2795,11 +2798,11 @@ int32_t readrgbimage(
   if (ascii)
     for (i = 0; i < N; i++)
     {
-      fscanf(fd, "%d", &c);
+      bool = fscanf(fd, "%d", &c);
       (UCHARDATA(*r))[i] = (uint8_t)c;
-      fscanf(fd, "%d", &c);
+      bool = fscanf(fd, "%d", &c);
       (UCHARDATA(*g))[i] = (uint8_t)c;
-      fscanf(fd, "%d", &c);
+      bool = fscanf(fd, "%d", &c);
       (UCHARDATA(*b))[i] = (uint8_t)c;
     } /* for i */
   else
@@ -3184,6 +3187,7 @@ int32_t readbmp(const char *filename, struct xvimage ** r, struct xvimage ** g, 
   struct BITMAPINFOHEADER InfoHeader;
   uint8_t *R, *G, *B;
   int32_t i, j, rs, cs;
+  size_t fread_out;
 
   fd = pink_fopen_read(filename);
 
@@ -3193,7 +3197,7 @@ int32_t readbmp(const char *filename, struct xvimage ** r, struct xvimage ** g, 
     return 0;
   }
 
-  fread(&(FileHeader.Signature), sizeof(char), 2, fd);
+  fread_out = fread(&(FileHeader.Signature), sizeof(char), 2, fd);
   freadulong(&(FileHeader.FileSize), fd);
   freadulong(&(FileHeader.reserved), fd);
   freadulong(&(FileHeader.DataOffset), fd);


### PR DESCRIPTION
removed a few warnings due to not assigning the output of fscanf and fread