### PR TITLE
small change to deal with the absence of long long in ITK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.txt.user
 *~
 
+obj

--- a/RORPO_multiscale_Usage/main.cpp
+++ b/RORPO_multiscale_Usage/main.cpp
@@ -435,7 +435,8 @@ int main(int argc, char **argv) {
                                                  maskPath);
             break;
         }
-        case itk::ImageIOBase::ULONGLONG:
+#ifdef ITK_SUPPORTS_LONGLONG
+	case itk::ImageIOBase::ULONGLONG:
         {
             Image3D<unsigned long long> image = dicom?Read_Itk_Image_Series<unsigned long long>(imagePath):Read_Itk_Image<unsigned long long>(imagePath);
             error = RORPO_multiscale_usage<unsigned long long>(image,
@@ -463,6 +464,7 @@ int main(int argc, char **argv) {
                                                       maskPath);
             break;
         }
+#endif // ITK_SUPPORTS_LONGLONG
         case itk::ImageIOBase::FLOAT:
         {
             Image3D<float> image = dicom?Read_Itk_Image_Series<float>(imagePath):Read_Itk_Image<float>(imagePath);

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -1,7 +1,19 @@
+Welcome to libRORPO, a mathematical morphology library for Path Operators. RORPO
+is a morphological vesselness operator, meant to detect vessels and other tubular
+structures in medical images.
+
+To compile this code you will need to also install the pybind11 submodule. This
+is achieved with the command:
+
+git submodule update --init
+
+
 ################ libRORPO ###############
 
 WARNING :
-All images must have an isotropic image resolution (cubic voxels).
+All images are expected to have an isotropic image resolution (cubic voxels).
+The software will produce a result if this not the case but the interpretation
+of this result will be questionable.
 
 ---------- File PO.hpp ----------
 


### PR DESCRIPTION
Some version of ITK, both old and recent, do not have a LONGLONG  or ULONGLONG type.

There is already a LONG and ULONG type and in large modern machines (ie not embedded or 32-bit Windows) these are 64-bit types already.

So I've just added a conditional compilation test, but the corresponding DEFINE must be set by hand for now.

Also very minor change to the documentation.