### PR TITLE
Only build pyRORPO when BUILD_PYRORPO option is set and Update window array when window option is not set for float/double input image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,13 @@ include_directories(
 if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "Release")
 	enable_testing()
 endif()
+
 add_subdirectory(libRORPO)
-add_subdirectory(docopt)
-add_subdirectory(RORPO_multiscale_Usage)
+
+if (NOT BUILD_PYRORPO)
+	add_subdirectory(docopt)
+	add_subdirectory(RORPO_multiscale_Usage)
+endif()
 
 if (BUILD_PYRORPO)
 	message("BUILD_PYRORPO is ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 project(RORPO)
 cmake_minimum_required(VERSION 3.2)
 
+option(BUILD_PYRORPO "Enable pyRORPO" OFF)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -31,4 +33,8 @@ endif()
 add_subdirectory(libRORPO)
 add_subdirectory(docopt)
 add_subdirectory(RORPO_multiscale_Usage)
-add_subdirectory(pyRORPO)
+
+if (BUILD_PYRORPO)
+	message("BUILD_PYRORPO is ON")
+	add_subdirectory(pyRORPO)
+endif ()

--- a/README.md
+++ b/README.md
@@ -3,16 +3,21 @@ Welcome to libRORPO, a mathematical morphology library for Path Operators. RORPO
 is a morphological vesselness operator, meant to detect vessels and other tubular
 structures in medical images.
 
-To compile this code you will need to also install the pybind11 submodule. This
-is achieved with the command:
-```
-git submodule update --init
-```
-
 **WARNING :
 All images are expected to have an isotropic image resolution (cubic voxels).
 The software will produce a result if this not the case but the interpretation
 of this result will be questionable.**
+
+## Build pyRORPO
+To generate python bindings, a shared library of RORPO, you will need to also install the pybind11 submodule. This
+is achieved with the command:
+```
+git submodule update --init
+```
+Then build the project with BUILD_PYRORPO option
+```
+cmake -DBUILD_PYRORPO=ON <path-to-source>
+```
 
 ## File PO.hpp
 **PO_3D**: Compute the Path Opening operator in one orientation. The 7 orientations are defined in the function RPO.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,28 @@ All images are expected to have an isotropic image resolution (cubic voxels).
 The software will produce a result if this not the case but the interpretation
 of this result will be questionable.**
 
-## Build pyRORPO
-To generate python bindings, a shared library of RORPO, you will need to also install the pybind11 submodule. This
-is achieved with the command:
+## Build
+
+```
+cmake [-DITK_DIR=<path/to/itk>|-DBUILD_PYRORPO=ON] <path-to-source>
+make [libRORPO | RORPO_multiscale_Usage | pyRORPO]
+```
+
+### Lib RORPO
+
+A compiled version of ITK is required to build:
+```
+cmake -DITK_DIR=</path/to/itk> ..
+```
+
+### pyRORPO
+
+pyRORPO requires access to pybind11 submodule:
 ```
 git submodule update --init
 ```
-Then build the project with BUILD_PYRORPO option
+
+Except that, it has no other dependencies so use the BUILD_PYRORPO parameter when configuring to avoid them:
 ```
 cmake -DBUILD_PYRORPO=ON <path-to-source>
 ```

--- a/libRORPO/CMakeLists.txt
+++ b/libRORPO/CMakeLists.txt
@@ -1,7 +1,7 @@
 # RORPO Lib
 
 project(libRORPO)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.2)
 
 # FIND OPENMP
 find_package( OpenMP REQUIRED)

--- a/pyRORPO/CMakeLists.txt
+++ b/pyRORPO/CMakeLists.txt
@@ -11,10 +11,6 @@ if(OPENMP_FOUND)
 endif()
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 
-# Find ITK
-find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
-
 add_subdirectory("${PROJECT_SOURCE_DIR}/pybind11")
 
 pybind11_add_module(${PROJECT_NAME}
@@ -22,4 +18,4 @@ pybind11_add_module(${PROJECT_NAME}
 )
 
 # LINK REQUIRED LIBS
-target_link_libraries( ${PROJECT_NAME} PRIVATE RORPO ${ITK_LIBRARIES} )
+target_link_libraries(${PROJECT_NAME} PRIVATE RORPO)

--- a/pyRORPO/README.md
+++ b/pyRORPO/README.md
@@ -6,6 +6,7 @@
 All resources required to generete the python module are inside the directory `/pyRORPO`.
 
 ## Usage
+A detailed documentation of pyRORPO module is [here](https://rorpo.readthedocs.io/).
 
 Building target `pyRORPO` will generate a dynamic library. This library can be imported as a python module :
 

--- a/pyRORPO/bind_RORPO.hpp
+++ b/pyRORPO/bind_RORPO.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Image/Image.hpp"
-#include "Image/Image_IO_ITK.hpp"
 
 #include "pyRORPO.hpp"
 

--- a/pyRORPO/bind_RORPO_multiscale.hpp
+++ b/pyRORPO/bind_RORPO_multiscale.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "Image/Image.hpp"
-#include "Image/Image_IO_ITK.hpp"
 
 #include "pyRORPO.hpp"
 

--- a/pyRORPO/bind_RPO.hpp
+++ b/pyRORPO/bind_RPO.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Image/Image.hpp"
-#include "Image/Image_IO_ITK.hpp"
 
 #include "pyRORPO.hpp"
 


### PR DESCRIPTION
```
git submodule update --init
```
Then build the project with BUILD_PYRORPO option
```
cmake -DBUILD_PYRORPO=ON <path-to-source>
```

- Update window min and window max even when window option is not set  (bug happen when float/double images + no window option) 
- Convert type int of window array to double for double images for precision.